### PR TITLE
Update angular-locker.js

### DIFF
--- a/src/angular-locker.js
+++ b/src/angular-locker.js
@@ -222,7 +222,7 @@
 					 */
 					get: function (key, def) {
 						if (!angular.isArray(key)) {
-							if (!this.has(key)) return def || void 0;
+							if (!this.has(key)) return arguments.length === 2 ? def : void 0;
 							return _unserializeValue(storage.getItem(prefix + key));
 						} else {
 							var items = {};


### PR DESCRIPTION
This way `locker.get('notExists', false)` will return `false` instead of `undefined`.

Before:
- `locker.get('notExists', false)` would return `undefined`
- `locker.get('notExists', 0)` would return`undefined`
- `locker.get('notExists', null)` would return `undefined`
- `locker.get('notExists', '')` would return `undefined`
- `locker.get('notExists', NaN)` would return `undefined`

Now:
- `locker.get('notExists', false)` returns `false`
- `locker.get('notExists', 0)` returns`0`
- `locker.get('notExists', null)` returns `null`
- `locker.get('notExists', '')` returns `''`
- `locker.get('notExists', NaN)` returns `NaN`
