### PR TITLE
feat(put): add support for passing a default value

### DIFF
--- a/src/angular-locker.js
+++ b/src/angular-locker.js
@@ -173,7 +173,7 @@
 
                     /**
                      * Out of the box drivers
-                     * 
+                     *
                      * @type {Object}
                      */
                     this._registeredDrivers = {
@@ -388,19 +388,24 @@
                      *
                      * @param  {Mixed}  key
                      * @param  {Mixed}  value
+                     * @param  {Mixed}  def
                      * @return {self}
                      */
-                    put: function (key, value) {
+                    put: function (key, value, def) {
                         if (! key) return false;
                         key = _value(key);
 
                         if (angular.isObject(key)) {
                             angular.forEach(key, function (value, key) {
-                                this._setItem(key, value);
+                                this._setItem(key, angular.isDefined(value) && value !== null ? value : def);
                             }, this);
                         } else {
                             if (! angular.isDefined(value)) return false;
-                            this._setItem(key, _value(value, this._getItem(key)));
+                            this._setItem(key, _value(value,
+                              angular.isDefined(this._getItem(key)) && this._getItem(key) !== null ?
+                                this._getItem(key) :
+                                def
+                            ));
                         }
 
                         return this;
@@ -570,7 +575,7 @@
                         this.forget(key);
 
                         var watchId = key + $scope.$id;
-                        
+
                         if (this._watchers[watchId]) {
                             // execute the de-registration function
                             this._watchers[watchId]();

--- a/test/spec/angular-locker.spec.js
+++ b/test/spec/angular-locker.spec.js
@@ -208,8 +208,22 @@ describe('angular-locker', function () {
 
                         expect(locker.get('fnKey')).toEqual(2);
                         expect(value).not.toBeDefined();
-                    }));
-                });
+                }));
+
+                it('should pass the default value to the function if the current item value does not exist and a default was specified', inject(function (locker) {
+                  var value = null;
+
+                  expect(locker.get('fnKey')).not.toBeDefined();
+
+                  locker.put('fnKey', function (param) {
+                      value = param;
+                      return 2;
+                  }, 1);
+
+                  expect(locker.get('fnKey')).toEqual(2);
+                  expect(value).toBe(1);
+                }));
+            });
 
             it('should put an item into the locker when passing a function as first param', inject(function (locker) {
 


### PR DESCRIPTION
This is to add back in logic that was part of #10 that got removed shortly after.  The logic was changed slightly to catch undefined/null values but let all other falsy values pass through unchanged.