### PR TITLE
Adds Browserify compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,6 @@
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-sauce-launcher": "^0.2.10",
     "karma-spec-reporter": "0.0.13"
-  }
+  },
+  "main": "dist/angular-locker.min.js"
 }


### PR DESCRIPTION
Adds "main" property to package.json to package can be required using Browserify without any kind of shim.