### PR TITLE
fix compatibility with latest Chrome v60.0.3080.5

### DIFF
--- a/src/angular-locker.js
+++ b/src/angular-locker.js
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * angular-locker
  *
  * A simple & configurable abstraction for local/session storage in angular projects.
@@ -341,8 +341,8 @@
                         if (! this._checkSupport()) {
                             _error('The browser does not support the "' + options.driver + '" driver');
                         }
-
-                        return this._driver.hasOwnProperty(this._getPrefix(_value(key)));
+                        /*D2NOVA Stephen Chen: hasOwnProperty() method doesn't work on MacOS latest Chrome Version v60.0.3080.5 */
+                        return this._driver.hasOwnProperty(this._getPrefix(_value(key))) || this._getItem(key);
                     };
 
                     /**


### PR DESCRIPTION
D2NOVA Stephen Chen
In latest Chrome on MacOS (Version 60.0.3080.5)
the angular-locker 2.0.4 will fail to read from localStorage.
i.e. locker.get(mykey) will return undefined even there is data stored with the key 'mykey'
the root cause is that in _exists() method

this._driver.hasOwnProperty(this._getPrefix(_value(key)))

is not working for this Chrome.

so the fix to that is to change to :

this._driver.hasOwnProperty(this._getPrefix(_value(key))) || this._getItem(key)